### PR TITLE
Adding specification for the forum operator role

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -93,8 +93,8 @@ The owner of a given role is responsible for creating and maintaining their role
 
 |https://bisq.community[Forum] Operator
 |{issues}/19[#19]
-|TODO
-|TODO
+|{specs}/forum-operator.adoc[forum-operator.adoc]
+|TBD
 
 |Founder
 |{issues}/1[#1]

--- a/forum-operator.adoc
+++ b/forum-operator.adoc
@@ -1,0 +1,44 @@
+= Forum operator
+:toc:
+:toclevels: 4
+:toc-placement!:
+
+Issue: https://github.com/bisq-network/roles/issues/19[bisq-network/roles#19]
+
+toc::[]
+
+== Purpose
+
+To maintain a forum suitable for support in using Bisq and other Bisq related discussions by users as well as members of the Bisq team.
+
+== Motivation
+
+In order to provide quality user experiance and understanding of the software the forum is maintained that allows for users to help each other with the issues they might be having with the software, as well as general questions about it, feedback and suggestions users and others might be having about Bisq. Bisq developers, arbitrators and other roles are also present on this forum to provide further assistance and information if needed.
+
+== Privileges
+
+The forum operator will have full administrative access to Discoruse forum, root access to server that hosts it, as well as the ownership of the domain of the forum.
+
+== General Requirements
+
+=== Bonding
+
+The operator MUST post a bond of **TBD** BSQ to assume this role.
+
+=== Reporting
+
+The operator SHOULD post a monthly report in the form of a comment on the linked GitHub issue for this role.
+
+=== Collaboration
+
+The operator MUST insure that there is another person with access to the forum in case he is not available when an emergency server maintnance is needed.
+
+== Special Requirements
+
+The operator MUST:
+
+ - keep the Discourse installation up and running
+ - keep the Discourse installation up to date with latest patches
+ - keep the Discoruse backups recent and secure
+ - respond promptly to any questions / requests in the #forum Slack channel (recommendation: set your Slack notification preferences for that channel to be notified on "all new messages" so you don’t miss anything)
+ - acknowledge / respond promptly to any issues submitted to the https://github.com/bisq-network/forum[bisq-network/forum] GitHub repository


### PR DESCRIPTION
I made the specification for the forum operator role (issue #19) and added the appropriate changes to the README.adoc file.
I made some assumptions here as the role specification wasn't very discussed yet and left the bonding amount to **TBD**.